### PR TITLE
Fix const correctness

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -165,7 +165,7 @@ void do_dump()
 
 namespace {
     extern "C" {
-        void _xmlStructuredErrorFunc (void *, xmlErrorPtr error)
+        void _xmlStructuredErrorFunc (void *, const xmlErrorPtr error)
         {
             switch (error->level) {
                 case XML_ERR_NONE:


### PR DESCRIPTION
Fedora rawhide is failing on an -fpermissive error. I can't make it warn in
gcc-13 but its easy to fix anyways.

    g++ -Isrc/dregarnuhr.p -Isrc -I../src -I/usr/include/libxml2 -I/usr/include/libxml++-5.0 -I/usr/lib64/libxml++-5.0/include -I/usr/include -I/usr/include/libpng16 -fdiagnostics-color=always -D_FILE_OFFSET_BITS=64 -Wall -Winvalid-pch -DBOOST_UT_DISABLE_MODULE -std=c++23 -O2 -flto=auto -ffat-lto-objects -fexceptions -g -grecord-gcc-switches -pipe -Wall -Werror=format-security -Wp,-U_FORTIFY_SOURCE,-D_FORTIFY_SOURCE=3 -Wp,-D_GLIBCXX_ASSERTIONS -specs=/usr/lib/rpm/redhat/redhat-hardened-cc1 -fstack-protector-strong -specs=/usr/lib/rpm/redhat/redhat-annobin-cc1 -m64 -mtune=generic -fasynchronous-unwind-tables -fstack-clash-protection -fcf-protection -fno-omit-frame-pointer -mno-omit-leaf-frame-pointer -DUSE_OS_TZDB=1 -DONLY_C_LOCALE=0 -DCPPHTTPLIB_BROTLI_SUPPORT -DCPPHTTPLIB_OPENSSL_SUPPORT -DCPPHTTPLIB_ZLIB_SUPPORT -DWITH_GZFILEOP -MD -MQ src/dregarnuhr.p/main.cpp.o -MF src/dregarnuhr.p/main.cpp.o.d -o src/dregarnuhr.p/main.cpp.o -c ../src/main.cpp
    ../src/main.cpp: In function void init():
    ../src/main.cpp:190:40: error: invalid conversion from void (*)(void*, xmlErrorPtr) {aka void (*)(void*, _xmlError*)} to xmlStructuredErrorFunc {aka void (*)(void*, const _xmlError*)} [-fpermissive]

     190 |     xmlSetStructuredErrorFunc(nullptr, _xmlStructuredErrorFunc);
         |                                        ^~~~~~~~~~~~~~~~~~~~~~~
         |                                        |
         |                                        void (*)(void*, xmlErrorPtr) {aka void (*)(void*, _xmlError*)}
    In file included from ../src/main.cpp:10:
    /usr/include/libxml2/libxml/xmlerror.h:898:57: note:   initializing argument 2 of void xmlSetStructuredErrorFunc(void*, xmlStructuredErrorFunc)
     898 |                                  xmlStructuredErrorFunc handler);
